### PR TITLE
Query robustness fixes.

### DIFF
--- a/src/adql/gavo/additionaltests.xml
+++ b/src/adql/gavo/additionaltests.xml
@@ -46,7 +46,7 @@
 	</query>
 	<query uuid="8b9aa804-59b3-11ec-beef-28d2445a8967">
 		<description>Numeric operands and strings mix.</description>
-		<adql valid="true" version="adql-2.1">SELECT 'text'*1323
+		<adql valid="true" version="adql-2.1">SELECT '30'*1323
 			from Y
 		</adql>
 	</query>

--- a/src/adql/gavo/geometry.xml
+++ b/src/adql/gavo/geometry.xml
@@ -44,8 +44,8 @@
 </adql>
   </query>
   <query uuid="052cd50e-4509-11e6-b60c-9d2c33f9b7a2">
-    <description>Invalid simple geometry predicates</description>
-    <adql valid="false" version="adql-2.1">select x from y where Point(2,3)=x
+    <description>Geometry value legal as a value expression</description>
+    <adql valid="true" version="adql-2.1">select x from y where Point(2,3)=x
 </adql>
   </query>
   <query uuid="0996bf74-4509-11e6-b60c-9d2c33f9b7a2">
@@ -69,9 +69,8 @@
 </adql>
   </query>
    <query uuid="dfd90750-450d-11e6-b20b-6d529bdffd4c">
-    <description>misc bad queries for error message optimization</description>
-    <adql valid="false" version="adql-2.1">SELECT POINT(3,4) FROM z
-</adql>
+    <description>two-arg point works in the select list</description>
+    <adql valid="true" version="adql-2.1">SELECT POINT(3,4) FROM z</adql>
   </query>
   <query uuid="c6a8aa4c-450d-11e6-b20b-6d529bdffd4c">
     <description>misc bad queries for error message optimization</description>
@@ -108,8 +107,7 @@ WHERE 1=INTERSECTS(CIRCLE('ICRS', 10, 10, 0.5),
 		TAP_UPLOAD.user_table.ra2000, a.dec2000, 0.016666666666666666)))
 </adql></query><query uuid="fd09fb58-4d01-11e6-8c9d-819288b39233"><description>STC-S</description><adql valid="true" version="adql-2.1">select * from foo where 1=CONTAINS(REGION('Position ICRS 1 2'), x)
 </adql></query><query uuid="1655f288-4d02-11e6-8c9d-819288b39233"><description>STC-S</description><adql valid="true" version="adql-2.1">select * from foo where 1=CONTAINS(
-		REGION('Union ICRS (Position 1 2 Intersection
-		(circle  1 2 3 box 1 2 3 4 circle 30 40 2))'),
+		REGION('Union ICRS (Position 1 2 Intersection (circle  1 2 3 box 1 2 3 4 circle 30 40 2))'),
 		REGION('circle GALACTIC 1 2 3'))
 
 </adql></query><query uuid="27fd6dd6-4d02-11e6-8c9d-819288b39233"><description>STC-S</description><adql valid="true" version="adql-2.1">select * from foo where 1=INTERSECTS(REGION('NOT (circle  1 2 3)'), x)

--- a/src/adql/gavo/regressionlike.xml
+++ b/src/adql/gavo/regressionlike.xml
@@ -78,5 +78,5 @@
 	ON ( width = dec )
 </adql></query><query uuid="56f8b6f0-59b2-11ec-9317-28d2445a8967"><description>COALESCE in select list</description><adql version="adql-2.1" valid="true">SELECT COALESCE(a, b, c,d) FROM x
 </adql></query><query uuid="704b5b76-59b2-11ec-ac92-28d2445a8967"><description>COALESCE in condition</description><adql version="adql-2.1" valid="true">SELECT count(*) FROM x
-WHERE COALESCE(a, b, c) IS NOT NULL
+WHERE COALESCE(a, b, c) = 0
 </adql></query></queries>

--- a/src/adql/gavo/whitespace.xml
+++ b/src/adql/gavo/whitespace.xml
@@ -55,17 +55,12 @@
 </query>
  <query uuid="118c7d86-4509-11e6-b60c-9d2c33f9b7a2">
     <description>Simple whitespace predicates</description>
-    <adql valid="true" version="adql-2.1">select x from y where CENTROID( 3 )=x
+    <adql valid="true" version="adql-2.1">select x from y where ROUND( 3 )=x
 </adql>
   </query>
-  <query uuid="1aa0786e-4509-11e6-b60c-9d2c33f9b7a2">
-    <description>Invalid simple whitespace predicates</description>
-	<adql valid="false" version="adql-2.1">select x from y where COUNT( * ) > 5
-</adql>
-  </query>
-    <query uuid="e48c4834-450d-11e6-b20b-6d529bdffd4c">
+  <query uuid="e48c4834-450d-11e6-b20b-6d529bdffd4c">
     <description>misc bad queries for error message optimization</description>
-	<adql valid="true" version="adql-2.1">SELECT POINT( 'junk' , 3, 4) FROM z
+	<adql valid="true" version="adql-2.1">SELECT POINT( 'ICRS' , 3, 4) FROM z
 </adql>
   </query>
    <query uuid="72395eda-4cff-11e6-866d-736653f6053b">


### PR DESCRIPTION
These changes are intended to make the tests somewhat more lenient to
parsers that short-circuit certain patterns that will fail at the database
level anyway (e.g., 'text'*30, 'junk' as a coordinate system).

Also, the COALESCE IS NULL example simply was misguided.  IS NULL, by
ADQL's grammar, can only be applied to column references, not to
expressions.