### PR TITLE
PEG syntax considerations

### DIFF
--- a/src/peg/adql2.1.peg
+++ b/src/peg/adql2.1.peg
@@ -477,10 +477,6 @@ user_defined_function <-
 	(_ value_expression (_ ',' _ value_expression)* _)?
 	')'
 
-numeric_primary	<-
-	value_expression_primary
-	/ numeric_value_function
-
 # We need to seriously re-write value_expression because PEG
 # doesn't have an actual longest-match operator.  Thus, we
 # cannot decide on the type of the first operand.

--- a/src/peg/adql2.1.peg
+++ b/src/peg/adql2.1.peg
@@ -1,6 +1,6 @@
 # Note: in the actual PEG definition comments start with #
 
-# ============================ The Gramma's root symbol
+# ============================ The Grammar's root symbol
 
 query_specification <-
 	with_clause? _

--- a/src/peg/adql2.1.peg
+++ b/src/peg/adql2.1.peg
@@ -1,9 +1,4 @@
 # Note: in the actual PEG definition comments start with #
-# =========================== Configurables for deployers
-
-# additional prefixes to be added here
-udf_prefix <-
-	'ivo_'
 
 # ============================ The Gramma's root symbol
 
@@ -245,13 +240,13 @@ identifier <-
 	(regular_identifier / delimited_identifier)
 
 delimited_identifier <-
-	'"' ('""' / '[^"]')+ '"'
+	'"' ('""' / !["])+ '"'
 
 regular_identifier <-
 	(!(keyword) letter (letter / digit / '_')*)
 
 character_string_literal <-
-	("'" ("''" / r"[^']")* "'" (Space+ comment _)*)+
+	("'" ("''" / !['])* "'" (Space+ comment _)*)+
 
 fold_function <-
 	('UPPER' / 'LOWER') _
@@ -280,7 +275,7 @@ geometry_function <-
 	/ extract_coord_sys
 
 bitwise_op <-
-	'&' / '|' / '^'
+	[&|^]
 
 bitwise_expression <-
 	'~' numeric_value_expression
@@ -456,13 +451,13 @@ point <-
 	_ ',' _ coordinates _ ')'
 
 numeric_value_expression <-
-	term (_ ('+' / '-') _ numeric_value_expression)*
+	term (_ [-+] _ numeric_value_expression)*
 
 term <-
-	factor (_ ('*' / '/') _ term)*
+	factor (_ [*/] _ term)*
 
 factor <-
-	('+' / '-')? numeric_primary
+	[-+]? numeric_primary
 
 numeric_value_function <-
 	math_function
@@ -531,7 +526,7 @@ numeric_expression_operand <-
 	numeric_value_expression
 
 numeric_expression_rest <-
-	('+' / '-' / '*' / '/') _ numeric_expression_operand
+	[-+*/] _ numeric_expression_operand
 
 approximate_numeric_literal <-
 	exact_numeric_literal 'E'
@@ -541,7 +536,7 @@ exact_numeric_literal	<-
 	(unsigned_integer '.')* unsigned_integer
 
 signed_integer <-
-	('+' / '-')? unsigned_integer
+	[-+]? unsigned_integer
 
 # TODO: We should take out character_string_literal here, MD thinks --
 # what sort of use case did people have in mind here?
@@ -566,13 +561,13 @@ unsigned_hexadecimal <-
 	'0x' hex_digit+
 
 digit <-
-	'[0-9]'
+	[0-9]
 
 hex_digit <-
-	'[0-9A-F]'
+	[0-9A-F]
 
 letter <-
-	'[a-zA-Z]'
+	[a-zA-Z]
 
 # Reserved words
 
@@ -684,7 +679,7 @@ ANY_CHAR <-
 	letter / digit / ' ' / '\t' / ',' / '' / '.'
 
 comment	<-
-	'--' '[^\n\r]*'
+	'--' (![\n\r])*
 
 _ <-
 	(comment / Space / EOL)*
@@ -693,10 +688,19 @@ __ <-
 	(comment / Space / EOL)+
 
 _a <-
-	!'[A-Z0-9_]'
+	![A-Z0-9_]
 
 Space <-
 	' '+ / '\t'
 
 EOL <-
 	'\r\n' / '\n' / '\r'
+
+EOF <-
+    !.
+
+# =========================== Configurables for deployers
+# additional prefixes to be added here
+udf_prefix <-
+	'ivo_'
+

--- a/src/peg/testpeg.py
+++ b/src/peg/testpeg.py
@@ -48,7 +48,10 @@ def get_parser(debug=False, root='query_specification'):
     peg_rules = re.sub('#', '// ', peg_rules)
 
     # adapt character range syntax
-    peg_rules = re.sub("'\\[", "r'[", peg_rules)
+    peg_rules = re.sub("\\[", "r'[", peg_rules)
+    peg_rules = re.sub("\\!r'\\[", "r'[^", peg_rules)
+    peg_rules = re.sub("\\]", "]'", peg_rules)
+    peg_rules = re.sub("EOF <-[^;]*;", "", peg_rules)
 
     return ParserPEG(peg_rules, 
        root,


### PR DESCRIPTION
(I added @gmantele and @msdemlei as reviewers for the time being, feel free to add whomever you feel adequate.)

Hi all,

as PEG adoption for the ADQL grammar definition draws near(er), I have been testing different parser generators recently. Namely:

* [Mouse](https://mousepeg.sourceforge.net/), written in Java.
* [`peg(1)`](https://www.piumarta.com/software/peg/), written in C.

I discovered by trial and error, that their definition of PEG and its syntax differ from the one defined by Bryan Ford in the [original paper](https://bford.info/pub/lang/peg.pdf) (cf. Figure 1 and Table 1). In other words, the original syntax looks like a formal definition rather than a standard one -- there doesn't seem to be any, actually. Other tools much more idiomatic tools exist: i.e., fitting the respective programming language.

These deviations range from aesthetical changes (separators and delimiters) to extensions and in some cases syntactic sugar -- you can see them on the links above. To give a couple of examples:

* Mouse only allows rules to be defined in `camelCase`, due to the underscore character `_` being an extra operator.
* Mouse having issues with character classes containing multiple groups, that is: the formal `rule <- [a-zA-Z]` becoming `rule = [a-z] / [A-Z]`
* Negation:  `peg(1)`, allows character classes to be negated with `[^s]`, the Mouse counterpart being `^[s]`, in both cases instead of the more formal `![s]`

In addition, both also define the first rule as the root of the parse tree... unlike arpeggio used by lyonetia.

I think that, for completeness purposes, following the formal definition would be the sensible decision, eventually adding some clarifications to deployers regarding the disparities between different generators and optionally offer some tools for conversion.

---

In this case, I have updated the `adql2.1.peg` file to reflect the syntax as defined by Bryan Ford, and made the required changes to the `testadql.py` file so the conversion to the arpeggio compliant PEG syntax does not fail. Sadly, tests fail, which we would need to check.

Finally, other errors encountered by the parsers are:

* ~~The rule `numeric_primary` is redefined~~ fixed: see 486116dbf8809f3ee6cd0c2977bf7d63839fa4b7
* The rules `ANY_CHAR`, `unsigned_hexadecimal`, `numeric_expression`, `string_expression`, `string_function`, `bitwise_expression`, `geometry_function` are defined but not used
